### PR TITLE
[feat] +cobra intergration

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,28 +1,16 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"os/exec"
 )
 
-func main() {
-	args := os.Args[1:]
-	rclone_args := []string{"--verbose", "--exclude=.DS_Store", "sync"}
-
-	// test againts --dry-run option
-	// TODO: map to separate config instance
-	for i := 0; i < len(args); i++ {
-		if args[i] == "--dry-run" {
-
-			os.Exit(0)
-		}
-	}
+func syncRemote(requestedRemote string, userPath string, direction string, dryRun bool) int {
+	rcloneArgs := []string{"--verbose", "--exclude=.DS_Store", "sync"}
 
 	config := loadConfig()
-	requestedRemote, userPath := splitRemotePath(args)
-	direction := getSyncDirection(args)
-
 	// get requested remote config. Exit, if not found
 	remote := config.Remotes[requestedRemote]
 	if remote.Remote == "" {
@@ -33,16 +21,67 @@ func main() {
 	remoteTarget := getRemoteRcTarget(config, remote, userPath)
 
 	if direction == "up" {
-		rclone_args = append(rclone_args, localTarget, remoteTarget)
+		rcloneArgs = append(rcloneArgs, localTarget, remoteTarget)
 	} else {
-		rclone_args = append(rclone_args, remoteTarget, localTarget)
+		rcloneArgs = append(rcloneArgs, remoteTarget, localTarget)
 	}
 
-	log.Println(rclone_args)
+	log.Println(rcloneArgs)
 
-	// run task
-	cmd := exec.Command("rclone", rclone_args...) //.Output()
+	if dryRun == true {
+		return 0
+	}
+
+	cmd := exec.Command("rclone", rcloneArgs...) //.Output()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Run()
+	return 0
+}
+
+func main() {
+	var DryRun bool
+
+	var rootCmd = &cobra.Command{
+		Use:   "echo [string to echo]",
+		Short: "Echo anything to the screen",
+		Long:  `echo is for echoing anything back. Echo works a lot like print, except it has a child command.`,
+		Args:  cobra.MinimumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+
+			//sync all vaults up
+			if len(args) == 0 {
+				config := loadConfig()
+
+				for requestedRemote, _ := range config.Remotes {
+					syncRemote(requestedRemote, "/", "up", DryRun)
+				}
+
+				os.Exit(0)
+			}
+
+			//sync all vaults down
+			if args[0] == "down" {
+				config := loadConfig()
+
+				for requestedRemote, _ := range config.Remotes {
+					syncRemote(requestedRemote, "/", "down", DryRun)
+				}
+
+				os.Exit(0)
+			}
+
+			//sync particular remote
+			requestedRemote, userPath := splitRemotePath(args)
+			direction := getSyncDirection(args)
+
+			syncRemote(requestedRemote, userPath, direction, DryRun)
+
+		},
+	}
+
+	//flags
+	rootCmd.PersistentFlags().BoolVarP(&DryRun, "dry-run", "d", false, "run generator without sync")
+
+	rootCmd.Execute()
 }


### PR DESCRIPTION
Added formal argument parser. Example usage:

* `rc [all]` — sync all vaults;
* `rc --dry-run` — generate rclone args without sync.